### PR TITLE
Moved jshint to a devDependency

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "aws-kinesis-agg",
-    "version": "4.0.2",
+    "version": "4.0.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -154,6 +154,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
             "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+            "dev": true,
             "requires": {
                 "exit": "0.1.2",
                 "glob": "^7.1.1"
@@ -194,6 +195,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
             "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+            "dev": true,
             "requires": {
                 "date-now": "^0.1.4"
             }
@@ -201,12 +203,14 @@
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
         },
         "date-now": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
+            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+            "dev": true
         },
         "debug": {
             "version": "3.1.0",
@@ -229,30 +233,40 @@
             "dev": true
         },
         "dom-serializer": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-            "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+            "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+            "dev": true,
             "requires": {
-                "domelementtype": "^1.3.0",
-                "entities": "^1.1.1"
+                "domelementtype": "^2.0.1",
+                "entities": "^2.0.0"
             },
             "dependencies": {
+                "domelementtype": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+                    "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+                    "dev": true
+                },
                 "entities": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-                    "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+                    "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+                    "dev": true
                 }
             }
         },
         "domelementtype": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+            "dev": true
         },
         "domhandler": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
             "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+            "dev": true,
             "requires": {
                 "domelementtype": "1"
             }
@@ -261,6 +275,7 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
             "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+            "dev": true,
             "requires": {
                 "dom-serializer": "0",
                 "domelementtype": "1"
@@ -269,7 +284,8 @@
         "entities": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-            "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
+            "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+            "dev": true
         },
         "escape-string-regexp": {
             "version": "1.0.5",
@@ -286,7 +302,8 @@
         "exit": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -328,6 +345,7 @@
             "version": "3.8.3",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
             "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+            "dev": true,
             "requires": {
                 "domelementtype": "1",
                 "domhandler": "2.3",
@@ -372,7 +390,8 @@
         "isarray": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+            "dev": true
         },
         "jmespath": {
             "version": "0.15.0",
@@ -381,15 +400,16 @@
             "dev": true
         },
         "jshint": {
-            "version": "2.9.7",
-            "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.7.tgz",
-            "integrity": "sha512-Q8XN38hGsVQhdlM+4gd1Xl7OB1VieSuCJf+fEJjpo59JH99bVJhXRXAh26qQ15wfdd1VPMuDWNeSWoNl53T4YA==",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.11.0.tgz",
+            "integrity": "sha512-ooaD/hrBPhu35xXW4gn+o3SOuzht73gdBuffgJzrZBJZPGgGiiTvJEgTyxFvBO2nz0+X1G6etF8SzUODTlLY6Q==",
+            "dev": true,
             "requires": {
                 "cli": "~1.0.0",
                 "console-browserify": "1.1.x",
                 "exit": "0.1.x",
                 "htmlparser2": "3.8.x",
-                "lodash": "~4.17.10",
+                "lodash": "~4.17.11",
                 "minimatch": "~3.0.2",
                 "shelljs": "0.3.x",
                 "strip-json-comments": "1.0.x"
@@ -575,8 +595,9 @@
         },
         "readable-stream": {
             "version": "1.1.14",
-            "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
             "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -599,7 +620,8 @@
         "shelljs": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-            "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
+            "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+            "dev": true
         },
         "should": {
             "version": "13.2.3",
@@ -689,7 +711,8 @@
         "string_decoder": {
             "version": "0.10.31",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+            "dev": true
         },
         "strip-ansi": {
             "version": "3.0.1",
@@ -702,7 +725,8 @@
         "strip-json-comments": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-            "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
+            "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+            "dev": true
         },
         "supports-color": {
             "version": "5.4.0",

--- a/node/package.json
+++ b/node/package.json
@@ -9,7 +9,6 @@
     },
     "dependencies": {
         "async": "2.6.1",
-        "jshint": "2.9.7",
         "protobufjs": "5.0.3"
     },
     "keywords": [
@@ -45,6 +44,7 @@
     },
     "devDependencies": {
         "aws-sdk": "^2.339.0",
+        "jshint": "^2.11.0",
         "mocha": "^5.0.0",
         "node-uuid": "^1.4.8",
         "should": "^13.2.1",


### PR DESCRIPTION
Moved jshint from dependencies to devDependencies
My main issue was a lambda > 3 MiB due to dist/jshint.js being included - i've had to do a workaround to remove in my deployment

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
